### PR TITLE
Change BCELoss in MLP

### DIFF
--- a/qlib/contrib/model/pytorch_nn.py
+++ b/qlib/contrib/model/pytorch_nn.py
@@ -267,7 +267,7 @@ class DNNModelPytorch(Model):
             loss = torch.mul(sqr_loss, w).mean()
             return loss
         elif loss_type == "binary":
-            loss = nn.BCELoss(weight=w)
+            loss = nn.BCEWithLogitsLoss(weight=w)
             return loss(pred, target)
         else:
             raise NotImplementedError("loss {} is not supported!".format(loss_type))
@@ -334,16 +334,8 @@ class Net(nn.Module):
             dnn_layers.append(seq)
         drop_input = nn.Dropout(0.05)
         dnn_layers.append(drop_input)
-        if loss == "mse":
-            fc = nn.Linear(hidden_units, output_dim)
-            dnn_layers.append(fc)
-
-        elif loss == "binary":
-            fc = nn.Linear(hidden_units, output_dim)
-            sigmoid = nn.Sigmoid()
-            dnn_layers.append(nn.Sequential(fc, sigmoid))
-        else:
-            raise NotImplementedError("loss {} is not supported!".format(loss))
+        fc = nn.Linear(hidden_units, output_dim)
+        dnn_layers.append(fc)
         # optimizer
         self.dnn_layers = nn.ModuleList(dnn_layers)
         self._weight_init()


### PR DESCRIPTION
Change BCELoss to BCEWithLogitsLoss

## Description
Change BCELoss to BCEWithLogitsLoss used in MLP model.

## Motivation and Context
The BCEWithLogitsLoss combines the sigmoid layer and the BCELoss in one class. It is more numerically stable than a plain Sigmoid followed by a BCELoss. It also keeps the net architecture identical for different loss functions.


## How Has This Been Tested?
- [ ] Pass the test by running: `pytest qlib/tests/test_all_pipeline.py` under upper directory of `qlib`.
- [x] If you are adding a new feature, test on your own test scripts.

<!--- **ATTENTION**: If you are adding a new feature, please make sure your codes are **correctly tested**. If our test scripts do not cover your cases, please provide your own test scripts under the `tests` folder and test them. More information about test scripts can be found [here](https://docs.python.org/3/library/unittest.html#basic-example), or you could refer to those we provide under the `tests` folder. -->

## Screenshots of Test Results (if appropriate):
1. Pipeline test:
2. Your own tests:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Fix bugs
- [x] Add new feature
- [ ] Update documentation
